### PR TITLE
pull in railties versions from parent repo

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     devise_security_extension (0.10.0)
       devise (>= 3.0.0, < 5.0)
-      railties (>= 3.2.6, < 6.0)
+      railties (~> 6.0.3, >= 3.2.6)
 
 GEM
   remote: https://rubygems.org/

--- a/devise_security_extension.gemspec
+++ b/devise_security_extension.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 2.1.0'
 
-  s.add_runtime_dependency 'railties', '>= 3.2.6', '< 6.0'
+  s.add_runtime_dependency 'railties', '~> 6.0.3', '>= 3.2.6'
   s.add_runtime_dependency 'devise', '>= 3.0.0', '< 5.0'
   s.add_development_dependency 'bundler', '>= 1.3.0', '< 2.0'
   s.add_development_dependency 'sqlite3', '~> 1.3.10'


### PR DESCRIPTION
The parent repo did the work to validate this code working in rails 6.0.x

This will allow us to update our current Rails apps to 6.0 as we are prevented from doing so currently.